### PR TITLE
 net: ethernet: asix: Fix asix kernel module autoload

### DIFF
--- a/drivers/net/ethernet/asix/ax88796c_main.c
+++ b/drivers/net/ethernet/asix/ax88796c_main.c
@@ -1571,6 +1571,12 @@ static const struct of_device_id ax88796c_dt_ids[] = {
 MODULE_DEVICE_TABLE(of, ax88796c_dt_ids);
 #endif
 
+static const struct spi_device_id asix_id[] = {
+	{ "ax88796c", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(spi, asix_id);
+
 static struct spi_driver ax88796c_spi_driver = {
 	.driver = {
 		.name = DRV_NAME,
@@ -1583,6 +1589,7 @@ static struct spi_driver ax88796c_spi_driver = {
 	.remove = ax88796c_remove,
 	.suspend = ax88796c_suspend,
 	.resume = ax88796c_resume,
+	.id_table = asix_id,
 };
 
 /* ----------------------------------------------------------------------------


### PR DESCRIPTION
With CONFIG_SPI_AX88796C set as a module, there are issues with
autoloading this kernel module.

For spi devices in OF the modalias exposed to userspace is
spi:<node type>, for the Asix AX88796C driver this is spi:ax88796c

spi:ax88796c

On the other hand, the asix module does not use the same alias:

alias:          of:N*T*Casix,ax88796c*

This happens because the SPI subsystem hardcodes spi:<spi->modalias>, as seen in
drivers/spi/spi.c:

static int spi_uevent(struct device *dev, struct kobj_uevent_env *env)
{
        const struct spi_device *spi = to_spi_device(dev);

        add_uevent_var(env, "MODALIAS=%s%s", SPI_MODULE_PREFIX, spi->modalias);
        return 0;
}

Thus we define the spi id table, add ax88796c to it and have the alias as reported by
the spi driver added so that userspace can correctly autoload the module for the device.

Signed-off-by: Florin Sarbu <florin@resin.io>